### PR TITLE
Add chat control 2 0 dossier translation

### DIFF
--- a/content/nl/docs/chat-control-2-0.md
+++ b/content/nl/docs/chat-control-2-0.md
@@ -1,0 +1,458 @@
+---
+title: "Chatcontrole: het kindermisbruik-scanvoorstel van de EU"
+description: "Dossier met de relevante achtergrond en gegevens over het chatcontrole wetsvoorstel van de EU."
+lead: "Oorspronkelijke publicatie: <a href='https://www.patrick-breyer.de/en/posts/chat-control/'>Chat Control: The EU’s CSEM scanner proposal</a><br> 
+Auteur: Patrick Breyer<br> 
+Publicatie: Patrick Breyer's website<br> 
+Datum: doorlopend geüpdate<br>
+In andere talen: <a href='https://www.patrick-breyer.de/beitraege/chatkontrolle/'>🇩🇪 Duits</a> | <a href='https://www.patrick-breyer.de/en/posts/chat-control/'>🇬🇧 Engels</a> | <a href='https://iloth.net/2023/05/traduction-du-dossier-chat-control-2-0-de-patrick-breyer/'>🇫🇷 Frans</a> | <a href='https://chatcontrol.se/'>🇸🇪 Zweeds</a><br>
+Hier volgt de vertaling in het Nederlands."
+date: 2023-07-05T08:49:31+00:00
+lastmod: 2023-07-05T08:49:31+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: 
+weight: 630
+toc: true
+---
+
+## Het einde van de privacy bij digitale correspondentie
+
+De Europese Commissie stelt voor om aanbieders van communicatiediensten te verplichten om alle privéchats, berichten en emails automatisch te doorzoeken op verdachte inhoud---in het algemeen en zonder onderscheid. Het verklaarde doel: Om kinderuitbuitingsmateriaal te vervolgen. Het resultaat: Massasurveillance door middel van volledig geautomatiseerde gelijktijdige surveillance van berichten en chats, en het einde van de privékarakter van digitale correspondentie.
+
+Andere aspecten van het voorstel zijn onder meer ineffectieve netwerkblokkering, doorlichten van persoonlijke wolkopslag inclusief privéfoto's, verplichte leeftijdsverificatie resulterend in het einde van anonieme communicatie, app-winkelcensuur en het uitsluiten van minderjarigen van de digitale wereld.
+
+### Chatcontrole 2.0 op elke slimme telefoon
+
+Op 11 mei 2022 [presenteerde de Europese Commissie een voorstel](https://ec.europa.eu/home-affairs/proposal-regulation-laying-down-rules-prevent-and-combat-child-sexual-abuse_en) dat chatcontrole---het doorzoeken van communicatie---***verplicht* zou stellen voor alle email- en berichtendienstaanbieders** en zelfs zou gelden voor tot nu toe veilig eind-tot-eind versleutelde communicatiediensten. Voorafgaand aan het voorstel had een openbare enquête uitgewezen dat [een meerderheid van de respondenten, zowel burgers als belanghebbenden, tegen het opleggen van een verplichting tot het gebruik van chatcontrole was](https://ec.europa.eu/info/law/better-regulation/have-your-say/initiatives/12726-Child-sexual-abuse-online-detection-removal-and-reporting-/public-consultation_en). Meer dan 80% van de respondenten was tegen de toepassing van chatcontrole op eind-tot-eind versleutelde communicatie.
+
+Momenteel is er [een regeling](https://www.patrick-breyer.de/en/chatcontrol-european-parliament-approves-mass-surveillance-of-private-communications/) die aanbieders *toestaat* communicatie vrijwillig te scannen (zogenaamde 'Chatcontrole 1.0'). Tot nu toe passen alleen enkele niet-versleutelde communicatiediensten uit de Verenigde Staten, zoals GMail, Facebook/Instagram Messenger, Skype, Snapchat, iCloud-email en Xbox, vrijwillig chatcontrole toe ([meer details hier](https://www.esafety.gov.au/sites/default/files/2022-12/BOSE%20transparency%20report%20Dec%202022.pdf)). Als gevolg van het voorstel om chatcontrole 2.0 te verplichten, verwacht de Commissie een 3,5-voudige toename van het aantal scanmeldingen ([met 354%](https://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=SWD:2022:0209:FIN:EN:PDF)).
+
+<video width="100%" controls>
+  <source src="https://www.patrick-breyer.de/wp-content/uploads/2023/01/chatcontrol-explainer.mp4" type="video/mp4">
+</video>
+<figcaption><i>Video met uitleg over chatcontrole, door de mensen van <a href="https://chat-kontrolle.eu">chat-kontrolle.eu</a> (in het Duits, met Engelse ondertiteling)</i></figcaption>
+
+### Het voorstel voor chatcontrole 2.0
+
+Dit is wat het huidige voorstel daadwerkelijk inhoudt.
+
+EU-chatcontrolevoorstel | Gevolgen
+-- | --
+Gedacht wordt aan chatcontrole, netwerkblokkering, verplichte leeftijdsverificatie voor berichten en chats, leeftijdsverificatie voor app-winkels en uitsluiting van minderjarigen van het installeren van veel apps. | --
+Alle diensten die normaal gesproken tegen een vergoeding worden aangeboden (inclusief door advertenties gefinancierde diensten) vallen binnen het bereik, zonder drempels in grootte, aantal gebruikers, enzovoorts. |  Alleen niet-commerciële diensten die niet door advertenties worden gefinancierd, zoals veel open-bronsoftware, vallen buiten het bereik.
+De betroffen communicatiediensten zijn onder meer telefonie, email, berichten, chats (ook als onderdeel van spelletjes, op een deel van spelletjes, op datingportalen, enzovoorts), videoconferenties. | Teksten, afbeeldingen, video's en spraak (bijv. videovergaderingen, spraakberichten, telefoontjes) zouden moeten worden gescand.
+Eind-tot-eind versleutelde berichtendiensten vallen binnen de reikwijdte van het voorstel. | Aanbieders van eind-tot-eind versleutelde communicatiediensten zullen op elke slimme telefoon berichten moeten scannen (scannen aan de cliëntzijde) en bij een treffer het bericht moeten melden bij de politie.
+Getroffen hostingservices zijn onder meer webhosting, sociale media, videostreamingdiensten, bestandshosting en wolkdiensten. | Zelfs persoonlijke opslag die niet wordt gedeeld, zoals Apple's iCloud, zal worden onderworpen aan chatcontrole.
+Diensten die waarschijnlijk gebruikt zouden kunnen worden voor illegaal materiaal of voor kinderlokkerij zijn verplicht om de inhoud van persoonlijke communicatie en opgeslagen gegevens te doorzoeken (chatcontrole) zonder verdenking en zonder onderscheid. | Aangezien vermoedelijk elke dienst ook wel voor illegale doeleinden wordt gebruikt, zullen alle diensten verplicht zijn om chatcontrole in te zetten.
+De autoriteit in het land van vestiging van de aanbieder is verplicht om de inzet van chatcontrole te gelasten. | Er is binnen een EU-land geen beoordelingsvrijheid met betrekking tot wanneer en in welke mate chatcontrole wordt gelast.
+Chatcontrole omvat geautomatiseerde zoekopdrachten naar bekende kindermisbruik-afbeeldingen en -video's, verdachte berichten of bestanden worden gerapporteerd aan de politie. | Volgens de Zwitserse federale politie is [80% van de meldingen](https://www.republik.ch/2022/12/08/die-dunklen-schatten-der-chatkontrolle) die ze ontvangen (meestal gebaseerd op de methode van *hashing*) crimineel niet relevant. Ook werd in Ierland slechts [20% van de rapporten](https://www.iccl.ie/news/an-garda-siochana-unlawfully-retains-files-on-innocent-people-who-it-has-already-cleared-of-producing-or-sharing-of-child-sex-abuse-material/) die in 2020 van het in de Verenigde Staten gebaseerde Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen werden ontvangen, bevestigd als daadwerkelijk 'kindermisbruikmateriaal'.
+Chatcontrole omvat ook automatisch zoeken naar onbekende kindermisbruikfoto's en -video's, verdachte berichten of bestanden zullen worden gerapporteerd aan de politie. | Machinaal zoeken naar onbekende misbruikrepresentaties is een experimentele procedure waarbij gebruik wordt gemaakt van machinaal leren ('kunstmatige intelligentie'). De algoritmen zijn niet toegankelijk voor het publiek en de wetenschappelijke gemeenschap, en het ontwerp bevat ook geen openbaarmakingsvereiste. Het foutenpercentage is onbekend en wordt niet beperkt door de ontwerpverordening. Vermoedelijk resulteren deze technologieën in gigantische hoeveelheden foute rapporten. De conceptwet stelt aanbieders in staat om geautomatiseerde treffermeldingen door te geven aan de politie zonder dat mensen deze controleren.
+Chatcontrole omvat machinaal zoeken naar mogelijke kinderlokkerij, verdachte berichten worden gemeld aan de politie. | Machinaal zoeken naar mogelijke kinderlokkerij is een experimentele procedure waarbij gebruik wordt gemaakt van machinaal leren ('kunstmatige intelligentie'). De algoritmen zijn niet beschikbaar voor het publiek en de wetenschappelijke gemeenschap, noch bevat het ontwerp een openbaarmakingsvereiste. Het foutenpercentage is onbekend en wordt niet beperkt door de ontwerpverordening, vermoedelijk resulteren deze technologieën in gigantische hoeveelheden foutieve meldingen.
+Communicatiediensten die kunnen worden misbruikt voor kinderlokkerij (dus alle) moeten de leeftijd van hun gebruikers verifiëren. | In de praktijk omvat leeftijdsverificatie volledige gebruikersidentificatie, wat betekent dat anonieme communicatie via email, berichten, enzovoorts effectief verboden zal worden. Klokkenluiders, mensenrechtenverdedigers en gemarginaliseerde groepen rekenen juist op de bescherming van anonimiteit.
+App-winkels moeten de leeftijd van hun gebruikers verifiëren en voorkomen dat kinderen of jongeren onder de 17 jaar apps installeren die kunnen worden misbruikt voor kinderlokkerij. | Alle communicatiediensten zoals berichten-apps, dating-apps of spelletjes kunnen worden misbruikt voor kinderlokkerij (volgens [onderzoeken](https://www.medienanstalt-nrw.de/fileadmin/user_upload/NeueWebsite_0120/Medienorientierung/Cybergrooming/211216_Cybergrooming-Zahlen_Praesentation_LFMNRW.pdf)) en zouden dan ook worden geblokkeerd voor gebruik door kinderen of jongeren.
+Internetaanbieders kunnen worden verplicht om de toegang tot verboden en niet-verwijderbare afbeeldingen en video's die buiten de EU worden gehost, te blokkeren door middel van netwerkblokkering (URL-blokkering). | Netwerkblokkering is technisch gezien ineffectief en gemakkelijk te omzeilen. Het resulteert bovendien in de constructie van een technische censuurinfrastructuur.
+
+### Analyse van het ontwerpverslag van rapporteur Javier Zarzalejos (EPP) (19 april 2023)
+
+- **Chatcontrole:** Verplicht willekeurig doorzoeken van privécorrespondentie en gegevens van onverdachte burgers staat er nog steeds in. De eis om "de opsporingsopdracht te beperken tot een identificeerbaar deel of onderdeel van een dienst", zoals specifieke kanalen of groepen (AM 128), gaat de goede kant op, maar garandeert niet dat zoekopdrachten gericht zijn op of beperkt worden tot specifieke personen die vermoedelijk verbonden zijn met kindermisbruik, zoals vereist zou zijn om nietigverklaring van de opsporingsbepalingen door het Hof van Justitie te vermijden. De bevindingen van de Onderzoeksdienst van het Europees Parlement worden nog niet weergegeven.
+- In tegenstelling tot de Commissie wil de rapporteur niet dat gebruikers worden geïnformeerd dat hun correspondentie (ten onrechte) is gemeld (AM 138).
+- **'Vrijwillige opsporing'/Chatcontrole:** Voorgestelde nieuwe bevoegdheid voor aanbieders om op eigen initiatief privécorrespondentie en gegevens van onverdachte burgers te doorzoeken, zelfs wanneer niet aan de voorwaarden van een opsporingsbevel wordt voldaan (AM 99). Wederom niet gericht op of beperkt tot specifieke personen die vermoedelijk verbonden zijn met kindermisbruik, zoals vereist om nietigverklaring door het Hof van Justitie te voorkomen.
+- **Eind-tot-eind versleuteling:** Verzwakken van encryptie is uitgesloten (AM 106), hoewel de formulering nog niet voldoende is om verplicht scannen aan de cliëntzijde met zekerheid uit te sluiten (sommigen stellen dat scannen aan de cliëntzijde het encryptieproces als zodanig niet zou verstoren).
+- **Controle van metadata:** Voorstel voor een nieuwe bevoegdheid voor het automatisch bewaren en analyseren van metadata voor vermeend verdachte communicatiepatronen door dienstenaanbieders (AM 106). Dergelijke technologie is wederom gesloten-bron en niet onafhankelijk geëvalueerd, en daarmee waarschijnlijk onbetrouwbaar met talloze fout-positieve resultaten. De Commissie waarschuwt dat "Dienstenaanbieders metadata niet beschouwen als een effectief instrument bij het opsporen van kindermisbruikmateriaal" en dat "metadata meestal onvoldoende zijn om onderzoeken te initiëren“ (p. 29). Bovenal garandeert de voorgestelde bepaling opnieuw niet dat de verwerking gericht is op of beperkt tot specifieke personen die vermoedelijk verbonden zijn met kindermisbruikmateriaal, zoals vereist door het La Quadrature-arrest van het Hof van Justitie (par. 172 pp.).
+- **Toegangsblokkering/verwijderingsopdrachten voor zoekmachines:** Ineffectieve blokkering van toegang tot kindermisbruikmateriaal is nog steeds van kracht. Voorstel voor een nieuwe bevoegdheid om kindermisbruikmateriaal te verwijderen uit zoekmachines en 'kunstmatige intelligentie'. Beide zijn niet effectief omdat het materiaal niet bij de bron wordt verwijderd.
+- **App-censuur voor kinderen:** App-winkels verplichten om te voorkomen dat minderjarigen communicatie-apps zoals WhatsApp, spelletjes, of chats installeren, staat er nog steeds in. Conceptrapport stelt voor om deze app-censuur uit te breiden (AM 101 pp.).
+- **Verbod op anonieme communicatie:** Eis aan communicatiediensten om de leeftijd van gebruikers te verifiëren staat er nog steeds in, waarbij verificatiesystemen anoniem gebruik effectief uitsluiten. Dit zou het einde betekenen van anonieme email- of berichten-accounts die klokkenluiders, politieke activisten enzovoorts nodig hebben.
+- Veelbelovend: Voorstel om een **adviesforum voor slachtoffers** op te richten (AM 273)
+- Veelbelovend: Diensten kunnen zorgen voor een "hoog niveau van privacy, veiligheid en **beveiliging door ontwerp en standaard**" (AM 79).
+
+<iframe title="#Chatcontrole uitgelegd" src="https://peertube.european-pirates.eu/videos/embed/d64e6e10-0ad0-4b37-8813-3f5bc329f03b" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups" width="100%" height="365" frameborder="0"></iframe>
+<figcaption><i>Video met uitleg over chatcontrole, door de Europese Piratenpartij (in het Engels). Meer video's over chatcontrole zijn beschikbaar in <a href="https://peertube.european-pirates.eu/videos/watch/playlist/2a8dc2ce-2dec-4250-bb0e-a6a7340f0f4c">deze afspeellijst</a>.</i></figcaption>
+
+### De onderhandelingen: een tijdlijn
+#### 2020: De Europese Commissie stelt 'tijdelijke' wetgeving voor die chatcontrole mogelijk maakt
+
+De [voorgestelde 'tijdelijke' wetgeving](https://www.europarl.europa.eu/RegData/docs_autres_institutions/commission_europeenne/com/2020/0568/COM_COM(2020)0568_EN.pdf) staat het doorzoeken van alle privéchats, berichten en emails op illegale afbeeldingen van minderjarigen en pogingen tot het contactleggen met minderjarigen toe. Hierdoor kunnen de dienstenaanbieders van Facebook Messenger, Gmail en anderen elk bericht scannen op verdachte tekst en afbeeldingen. Dit gebeurt in een volledig geautomatiseerd proces, mede door gebruik te maken van foutgevoelige 'kunstmatige intelligentie'. Als een algoritme een bericht als verdacht beschouwt, worden de inhoud en metagegevens ervan (meestal automatisch en zonder menselijke verificatie) bekendgemaakt aan een particuliere organisatie in de Verenigde Staten en van daaruit aan nationale politieautoriteiten over de hele wereld. De gerapporteerde gebruikers worden niet op de hoogte gebracht.
+
+#### 6 juli 2021: Het Europees Parlement [keurt de wetgeving goed die chatcontrole mogelijk maakt](https://www.patrick-breyer.de/en/chatcontrol-european-parliament-approves-mass-surveillance-of-private-communications/)
+
+Het Europees Parlement stemde voor de ePrivacy-afwijking, die vrijwillige chatcontrole mogelijk maakt voor berichten- en emaildienstenaanbieders. Als gevolg hiervan voeren sommige dienstverleners in de Verenigde Staten, zoals Gmail en Outlook.com, al dergelijke geautomatiseerde bericht- en chatcontroles uit.
+
+#### 9 mei 2022: Europarlementariër Patrick Breyer heeft een rechtszaak [aangespannen](https://www.patrick-breyer.de/en/destruction-of-digital-privacy-of-correspondence-lawsuit-filed-against-chat-control/) tegen het bedrijf Meta uit de Verenigde Staten
+
+Volgens de [jurisprudentie van het Europese Hof van Justitie](http://curia.europa.eu/juris/document/document.jsf?text=&docid=232084&pageIndex=0&doclang=EN&mode=req&dir=&occ=first&part=1) **schendt de permanente en uitgebreide geautomatiseerde analyse van privécommunicatie fundamentele rechten en is deze verboden** (punt 177). Voormalig rechter van het Europese Hof van Justitie prof. dr. Ninon Colneric heeft de plannen uitgebreid geanalyseerd en **concludeert in een [juridische beoordeling](https://www.patrick-breyer.de/wp-content/uploads/2021/03/Legal-Opinion-Screening-for-child-pornography-2021-03-04.pdf) dat de EU-wetgevingsplannen over chatcontrole niet in overeenstemming zijn met de jurisprudentie van het Europese Hof van Justitie en in strijd zijn met de grondrechten van alle EU-burgers** op eerbiediging van de persoonlijke levenssfeer, gegevensbescherming en vrijheid van meningsuiting. Op basis hiervan werd de rechtszaak aangespannen.
+
+#### 11 mei 2022: De Commissie presenteert een voorstel om chatcontrole verplicht te stellen voor dienstverleners
+
+Op 11 mei 2022 kwam **de Europese Commissie met een tweede wetsvoorstel, waarin de Europese Commissie alle aanbieders van chat-, berichten- en emaildiensten verplicht om deze massasurveillancetechnologie in te zetten zonder enige verdenking. [Uit een representatieve enquête die in maart 2021 is gehouden, blijkt echter duidelijk dat een meerderheid van de Europeanen tegen het gebruik van chatcontrole is.](https://www.patrick-breyer.de/en/poll-72-of-citizens-oppose-eu-plans-to-search-all-private-messages-for-allegedly-illegal-material-and-report-to-the-police/)** ([Gedetailleerde enquêteresultaten vind je hier.](https://nextcloud.pp-eu.eu/index.php/s/5bkdRGyxnAciNBz))
+
+- **8 mei 2022:** Bijeenkomst Raadswerkgroep Rechtshandhaving
+- **22 juni 2022:** Bijeenkomst Raadswerkgroep Rechtshandhaving
+- **5 juli 2022:** Bijeenkomst Raadswerkgroep Rechtshandhaving
+- **20 juli 2022:** [Bijeenkomst](https://www.patrick-breyer.de/en/chat-control-internal-documents-show-how-divided-the-eu-member-states-are/) Raadswerkgroep Rechtshandhaving ([Compromistekst](https://data.consilium.europa.eu/doc/document/ST-12354-2022-INIT/en/pdf))
+- **6 september 2022:** Bijeenkomst Raadswerkgroep Rechtshandhaving
+- **22 september 2022:** Bijeenkomst Raadswerkgroep Rechtshandhaving (Compromistekst:  [Art. 1-2](https://www.patrick-breyer.de/wp-content/uploads/2022/11/Chatcontrol-Presidency-compromise-of-26.10.22-csam-articles-1-2.pdf), [25-39](https://www.statewatch.org/media/3541/eu-council-csa-regulation-compromise-13514-22.pdf))
+- **28 september 2022:** Bijeenkomst Raadwerkplaats over opsporingstechnologieën
+- **5 oktober 2022:** Bijeenkomst Raadswerkgroep Rechtshandhaving
+- **10 oktober 2022: [Het voorstel werd gepresenteerd en besproken in de leidende LIBE-commissie van het Europees Parlement](https://www.patrick-breyer.de/en/eu-chat-control-negotiations-kick-off-commissioner-johansson-defends-controversial-surveillance-law-before-libe-committee/) ([video-opname](https://multimedia.europarl.europa.eu/de/webstreaming/libe-committee-meeting_20221010-1500-COMMITTEE-LIBE))**
+- **19 oktober 2022:** Bijeenkomst Raadswerkgroep Rechtshandhaving
+- **3 november 2022:** [Raadsvergadering](https://www.patrick-breyer.de/wp-content/uploads/2023/02/221103-Council-meeting-notes-EN.pdf)
+- **24 november 2022:** [Raadswerkplaats](https://www.patrick-breyer.de/wp-content/uploads/2023/02/221124-Council-meeting-notes-EN.pdf) over leeftijdsverificatie en encryptie
+- **30 november 2022:** [Eerste LIBE schaduwbijeenkomst](https://www.patrick-breyer.de/en/first-parliamentary-amendments-on-eu-child-sexual-abuse-regulation-some-poison-teeth-are-pulled-but-indiscriminate-chat-control-still-looming/)
+- **14 december 2022:** LIBE schaduwbijeenkomst (hoorzittingen)
+- **10 januari 2023:** LIBE schaduwbijeenkomst (hoorzittingen)
+- **19 en 20 januari 2023: [Bijeenkomst van de Raadswerkgroep wetshandhaving politie](https://www.patrick-breyer.de/wp-content/uploads/2023/02/230119-Council-meeting-notes-EN.pdf)**
+- **24 januari 2023:** LIBE schaduwbijeenkomst (hoorzittingen)
+- **7 februari 2023:** LIBE schaduwbijeenkomst (techbedrijven)
+- **27 februari 2023:** LIBE schaduwbijeenkomst
+- **7 maart 2023:** LIBE schaduwbijeenkomst
+- **16 maart 2023:** [Raadsgroep rechtshandhaving](https://www.patrick-breyer.de/wp-content/uploads/2023/04/230316_WGLE_en.pdf) ([Besproken ontwerpcompromis](https://www.patrick-breyer.de/wp-content/uploads/2023/03/2023-03-09_LEWP_CSAR_Presidency-compromise.pdf))
+- **21 maart 2023:** LIBE schaduwbijeenkomst
+- **29 maart 2023:** [Bijeenkomst](https://www.patrick-breyer.de/wp-content/uploads/2023/06/230329_CSAM-COU-en-GB.pdf) raadswerkgroep rechtshandhaving
+- **Eind maart:** Vervangende effectbeoordeling wordt ingediend
+- **13 april 2023:** [Verklaring van de Duitse federale regering](https://www.patrick-breyer.de/wp-content/uploads/2023/04/230405_Stellungnahme-BReg-EN.pdf)
+- **13 april 2023:** [Presentatie van effectenbeoordeling in LIBE](https://www.patrick-breyer.de/en/eu-parliaments-research-service-confirms-chat-control-violates-fundamental-rights/)
+- **19 april 2023:** [LIBE-rapporteur dient conceptrapport in](https://www.patrick-breyer.de/en/chat-control-lead-negotiator-proposes-to-add-voluntary-detection-orders-and-metadata-scanning/)
+- **25 april 2023**: Groep rechtshandhaving van de Raad ([Besproken ontwerpcompromis](https://data.consilium.europa.eu/doc/document/ST-7842-2023-INIT/en/pdf))
+- **26 april 2023:** [Presentatie conceptrapport in LIBE](https://www.patrick-breyer.de/en/patrick-breyer-on-chat-control-to-ensure-the-safety-of-children-online-we-need-a-new-approach/)
+- **8-19 mei 2023:** Deadline voor het indienen van amendementen
+- **25-26 mei 2023:** Raadswerkgroep rechtshandhaving ([Besproken ontwerpcompromis](https://www.patrick-breyer.de/wp-content/uploads/2023/05/Presidency-council-compromise-17.05.2023-CSAM-chatcontrol.pdf))
+- **31 mei 2023:** [Bijeenkomst Coreper I](https://netzpolitik.org/2023/staendige-vertreter-eu-staaten-wollen-chatkontrolle-trotz-warnung-ihrer-juristen/#2023-05-31_St%C3%A4V_AStV_CSA-VO)
+- ~~**31 mei 2023:** Schaduwbijeenkomst~~
+- **7 juni 2023:** Schaduwbijeenkomst
+- **8 & 9 juni 2023:** Raad Justitie en Binnenlandse Zaken neemt gedeeltelijke algemene benadering aan ([Besproken ontwerpcompromis](https://www.patrick-breyer.de/wp-content/uploads/2023/06/2023.06.08-Council-Swedish-presidency-compromise.pdf))
+- **28 juni 2023:** Schaduwbijeenkomst
+- **5 juli 2023:** Schaduwbijeenkomst
+- **12 juli 2023:** Schaduwbijeenkomst
+- **19 juli 2023:** Schaduwbijeenkomst
+- **September 2023:** Stemming in de LIBE-commissie
+- **28 september 2023: [Beoogde goedkeuring van de algemene oriëntatie door de EU-Raad](https://data.consilium.europa.eu/doc/document/ST-11106-2023-INIT/en/pdf)**
+- **Oktober 2023:** Stemming in de plenaire vergadering
+- **December 2023:** Trialoogovereenkomst
+
+### De onderhandelaars
+
+De bij het Europees Parlement betrokken actoren: de rapporteur (aangegeven met een *) en schaduwrapporteurs.[^1]
+
+∖ | EVP | S&D | Renew | Groenen/EVA | Linkse Fractie | ECH | ID
+-- | -- | -- | -- | -- | -- | -- | -- 
+**LIBE** (hoofd) | **[Javier Zarzalejos](https://www.europarl.europa.eu/meps/en/197606/JAVIER_ZARZALEJOS/home)*** | [Paul Tang](https://www.europarl.europa.eu/meps/en/125020/PAUL_TANG/home) | [Hilde Vautmans](https://www.europarl.europa.eu/meps/en/130100/HILDE_VAUTMANS/home) | [Patrick Breyer](http://patrick-breyer.de/) | [Cornelia Ernst](https://www.europarl.europa.eu/meps/en/96852/CORNELIA_ERNST/home) | [Vincenzo Sofo](https://www.europarl.europa.eu/meps/en/204334/VINCENZO_SOFO/home) | [Annalisa Tardino](https://www.europarl.europa.eu/meps/en/197806/ANNALISA_TARDINO/home)
+**IMCO** | [Marion Walsmann](https://www.europarl.europa.eu/meps/en/197429/MARION_WALSMANN/home) | [Alex Aguis Saliba](https://www.europarl.europa.eu/meps/en/197403/ALEX_AGIUS%20SALIBA/home) | [Catharina Rinzema](https://www.europarl.europa.eu/meps/en/229519/CATHARINA_RINZEMA/home) | [Marcel Kolaja](https://www.kolaja.eu/en/) | [Kateřina Konečná](https://www.europarl.europa.eu/meps/en/23699/KATERINA_KONECNA/home) | [Adam Bielan](https://www.europarl.europa.eu/meps/en/23788/ADAM_BIELAN/home) | [Jean-Lin Lacapelle](https://www.europarl.europa.eu/meps/en/204421/JEAN-LIN_LACAPELLE/home)
+**CULT** | [Asim Ademov](https://www.europarl.europa.eu/meps/en/189525/ASIM_ADEMOV/home) | [Marcos Ros Sempere](https://www.europarl.europa.eu/meps/en/204413/MARCOS_ROS+SEMPERE/home) | [Lucia Duris Nicolsonova](https://www.europarl.europa.eu/meps/en/197766/LUCIA_DURIS%20NICHOLSONOVA/home) | [Marcel Koloja](https://www.kolaja.eu/en/) | [Niyazi Kizilyürek](https://www.europarl.europa.eu/meps/en/197415/NIYAZI_KIZILYUREK/home) | [Elzbieta Kruk](https://www.europarl.europa.eu/meps/en/197532/ELZBIETA_KRUK/home) | [Catherine Griset](https://www.europarl.europa.eu/meps/en/94649/CATHERINE_GRISET/home)
+**FEMM** | [Eleni Stavrou](https://www.europarl.europa.eu/meps/en/239271/ELENI_STAVROU/home) | [Heléne Fritzon](https://www.europarl.europa.eu/meps/en/197391/HELENE_FRITZON/home) | [Karen Melchior](https://www.europarl.europa.eu/meps/en/197567/KAREN_MELCHIOR/home) | [Pierrette Herzberger-Fofana](https://www.europarl.europa.eu/meps/en/197459/PIERRETTE_HERZBERGER-FOFANA/home) | [Sandra Pereira](https://www.europarl.europa.eu/meps/en/197754/SANDRA_PEREIRA/home) | [Jadwiga Wiśniewska](https://www.europarl.europa.eu/meps/en/124877/JADWIGA_WISNIEWSKA/home) | 
+**BUDG** | [Niclas Herbst](https://www.europarl.europa.eu/meps/en/197412/NICLAS_HERBST/home) | [Nils Ušakovs](https://www.europarl.europa.eu/meps/en/197810/NILS_USAKOVS/home) | [Nils Torvalds](https://www.europarl.europa.eu/meps/en/114268/NILS_TORVALDS/home) | [Alexandra Geese](https://www.europarl.europa.eu/meps/en/183916/ALEXANDRA_GEESE/home) | [Silvia Modig](https://www.europarl.europa.eu/meps/en/197805/SILVIA_MODIG/home) | [Bogdan Rzońca](https://www.europarl.europa.eu/meps/en/197545/BOGDAN_RZONCA/home) | [Joachim Kuhs](https://www.europarl.europa.eu/meps/en/197482/JOACHIM_KUHS/home)
+
+[^1]: **Toelichting op de afgekorte partijnamen:** ECH = Europese Conservatieven en Hervormers; EVP = Europese Volkspartij; Groenen/EVA = De Groenen/Europese Vrije Alliantie; ID = Identiteit en Democratie; Linkse Fractie = Linkse Fractie in het Europees Parlement - GUE/NGL; Renew = Hernieuw Europa; S&D = Socialisten & Democraten. **Toelichting op de afgekorte commissienamen:** BUDG = Budgetcommissie; CULT = Commissie cultuur en onderwijs; FEMM = Commissie vrouwenrechten en gendergelijkheid; IMCO = Commissie interne markt en consumentenbescherming; LIBE = Commissie burgerlijke vrijheden, justitie en binnenlandse zaken.
+
+## Wat betekent dit voor jou?
+
+### Scannen van berichten en chatcontrole
+
+- **Al je chatgesprekken en emails** zullen  automatisch worden doorzocht op verdachte inhoud. Niets blijft vertrouwelijk of geheim. Er is geen gerechtelijk bevel of een verdenking vereist voor het doorzoeken van je berichten. Het gebeurt altijd en automatisch.
+- Als een algoritme de inhoud van een bericht als verdacht classificeert, kunnen **je privé- of intieme foto's** worden bekeken door personeel en aannemers van internationale bedrijven en politieautoriteiten. Ook kunnen je privé-naaktfoto's worden bekeken door mensen die je niet kent, in wiens handen jouw foto's niet veilig zijn.
+- **Flirts en seksten kunnen worden gelezen** door personeel en aannemers van internationale bedrijven en politieautoriteiten, omdat tekstherkenningsfilters die op zoek zijn naar 'kinderlokkerij' vaak ten onrechte intieme chats eruit pikken.
+- **Je kunt ten onrechte worden aangegeven en onderzocht** wegens vermeende verspreiding van kindermisbruikmateriaal. Van berichten- en chatcontrole-algoritmen is bekend dat ze volledig legale vakantiefoto's eruit pikken, bijvoorbeeld van kinderen op een strand. Volgens de Zwitserse federale politieautoriteiten blijkt [80% van alle machinaal gegenereerde rapporten](https://www.republik.ch/2022/12/08/die-dunklen-schatten-der-chatkontrolle) ongegrond te zijn. Ook in Ierland werd slechts [20% van de rapporten](https://www.iccl.ie/news/an-garda-siochana-unlawfully-retains-files-on-innocent-people-who-it-has-already-cleared-of-producing-or-sharing-of-child-sex-abuse-material/) van het Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen die in 2020 werden ontvangen, bevestigd als daadwerkelijk 'kindermisbruikmateriaal'. Bijna [40% van alle strafrechtelijke onderzoeksprocedures](https://www.polizei-beratung.de/startseite-und-aktionen/aktuelles/detailansicht/polizeiliche-kriminalstatistik-2021/) die in Duitsland zijn ingeleid wegens 'kindermisbuik' is gericht op minderjarigen.
+- Op je volgende **reis naar het buitenland** kun je grote problemen verwachten. Door machines gegenereerde rapporten over je communicatie kunnen zijn doorgegeven aan andere landen, zoals de Verenigde Staten, waar geen gegevensprivacy bestaat---met onvoorspelbare resultaten.
+- **Inlichtingendiensten en hackers kunnen mogelijk je privéchats en emails bespioneren.** De deur staat open voor iedereen die over de technische middelen beschikt om je berichten te lezen als de veilige versleuteling wordt verwijderd om berichten te kunnen doorlichten.
+- **Dit is slechts het begin.** Als de technologie voor berichten- en chatcontrole eenmaal is ingevoerd, wordt het heel makkelijk om ze voor andere doeleinden te gebruiken. En wie garandeert dat deze strafbaarstellingsmachines in de toekomst niet meer gebruikt zullen worden op onze slimme telefoons en laptops?
+
+### Leeftijdsverificatie
+
+- Je kunt **geen anonieme email- of berichten-accounts meer opzetten of anoniem chatten** zonder dat je identificatie of je gezicht hoeft te tonen, waardoor je identificeerbaar wordt en het risico loopt op gegevenslekken. Dit belemmert bijvoorbeeld gevoelige chats over geaardheid, anonieme mediacommunicatie met bronnen (bijvoorbeeld klokkenluiders) en politieke activiteiten.
+- **Als je onder de 17 jaar bent, kun je de volgende apps uit de app-winkel niet meer installeren** (opgegeven reden: risico op kinderlokkerij): Berichten-apps zoals Whatsapp, Snapchat, Telegram of Twitter; sociale media-apps zoals Instagram, TikTok of Facebook; spelletjes zoals FIFA, Minecraft, GTA, Call of Duty, Roblox; dating-apps; videoconferentie-apps zoals Zoom, Skype, of Facetime.
+- Als je geen app-winkel gebruikt, wordt de naleving van de minimumleeftijd van de aanbieder nog steeds gecontroleerd en afgedwongen. **Als je onder de 16 bent, dan kun je geen gebruik meer maken van Whatsapp** vanwege de voorgestelde vereisten voor leeftijdsverificatie. Hetzelfde geldt voor de online functies van het spel FIFA 23. **Als je onder de 13 jaar oud bent, dan kun je geen gebruik meer maken van TikTok, Snapchat of Instagram.**
+
+[Lees meer argumenten tegen berichten- en chatcontrole](#aanvullende-informatie-en-argumenten).
+
+[Kom erachter wat je kunt doen om berichten- en chatcontrole te stoppen](#wat-kun-je-doen).
+
+## Wat kun je doen?
+
+Vrees je dat deze wet **enorme schade** zou toebrengen aan de grondrechten en dat dit de verkeerde aanpak is? Hier zijn dingen die je kunt doen.
+
+### 1. Teken de petitie
+
+Teken de petitie 'Kinderen verdienen [een veilig en veilig internet](https://civicrm.edri.org/stop-scanning-me)' en deel deze.
+
+### 2. Voer de druk op onderhandelaars op
+
+Het gaat er nu om de **druk op de onderhandelaars op te voeren**:
+- Neem contact op met je regering die onderhandelt in de Raad. Neem contact op met [de permanente vertegenwoordiging van de Nederlandse regering in de Raad van de Europese Unie](https://www.permanentevertegenwoordigingen.nl/permanente-vertegenwoordigingen/pv-eu-brussel) of met het Ministerie van Binnenlandse Zaken.  
+  - **[Permanente vertegenwoordiging van Nederland](https://www.permanentevertegenwoordigingen.nl/permanente-vertegenwoordigingen/pv-eu-brussel)**    
+Email: BRE@minbuza.nl  
+Adres:  Kortenberglaan 4-10, 1040 Brussel, België  
+Telefoon: (+32) 2679 1711  
+[Twitter](https://twitter.com/NLatEU) | 
+[Instagram](http://instagram.com/nl_at_eu) | 
+[LinkedIn](https://www.linkedin.com/company/permanente-vertegenwoordiging-van-het-koninkrijk-der-nederlanden-bij-de-europese-unie/)  
+Contacturen: Maa-Vrij 09:00-16:30 uur
+- Neem contact op met je leden van het Europees Parlement! De zogenaamde schaduwrapporteurs hebben de leiding over de onderhandelingen. Hier vind je de contactgegevens:
+   - [Javier Zarzalejos](https://www.europarl.europa.eu/meps/en/197606/JAVIER_ZARZALEJOS/home)---rapporteur voor de EVP-fractie
+   - [Paul Tang](https://www.europarl.europa.eu/meps/en/125020/PAUL_TANG/home)---schaduwrapporteur voor de S&D-fractie
+   - [Patrick Breyer](http://patrick-breyer.de/)---schaduwrapporteur voor de Verts/ALE-fractie
+   - [Hilde Vautmans](https://www.europarl.europa.eu/meps/en/130100/HILDE_VAUTMANS/home)---schaduwrapporteur voor de Renew-groep
+   - [Annalisa Tardino](https://www.europarl.europa.eu/meps/en/197806/ANNALISA_TARDINO/home)---schaduwrapporteur voor de ID-fractie
+   - [Vincenzo Sofo](https://www.europarl.europa.eu/meps/en/204334/VINCENZO_SOFO/home)---schaduwrapporteur voor de ECR-fractie
+   - [Cornelia Ernst](https://www.europarl.europa.eu/meps/en/96852/CORNELIA_ERNST/home)---schaduwrapporteur voor de Linkse fractie
+
+Vertel hen beleefd je zorgen over chatcontrole ([lees de argumenten hier](#aanvullende-informatie-en-argumenten)). Ervaring leert dat telefoontjes effectiever zijn dan emails of brieven. De officiële naam van de geplande verplichte chatcontrolewet is 'Voorstel voor een verordening houdende regels ter voorkoming en bestrijding van seksueel misbruik van kinderen'.
+
+### 3. Praat met mensen
+
+Praat erover! Informeer anderen over de gevaren van chatcontrole. [Hier kun je tweet-sjablonen, foto's en video's vinden om te delen](https://nextcloud.pp-eu.eu/index.php/s/qLreyoZRE3B9W3T) (voornamelijk in het Engels en Duits). Natuurlijk kun je ook je eigen afbeeldingen en video's maken 🫶
+
+### 4. Genereer aandacht op sociale media
+
+Genereer aandacht op social media! Gebruik de hashtags **#ChatControle** en **#Briefgeheim** (of voor het Engels #ChatControl en #SecrecyOfCorrespondence).
+
+### 5. Genereer media-aandacht
+
+Genereer media-aandacht! Tot nu toe hebben zeer weinig media in Nederland aandacht besteed aan de chatcontroleplannen van de EU. Neem contact op met kranten en vraag hen om over het onderwerp te schrijven---online en offline.
+
+### 6. Vraag je dienstenaanbieders
+
+**Vraag het je email-, berichten- en chatdienstenaanbieders wat ze doen!** Vermijd Gmail, Facebook Messenger, Outlook.com en de chatfunctie van Xbox, waar al willekeurige chatcontrole plaatsvindt. Vraag je email-, berichten- en chatdienstenaanbieders of ze over het algemeen privéberichten controleren op verdachte inhoud, of van plan zijn dit te doen.
+
+<!-- ### Afbeeldingen en info-afbeeldingen die je kunt downloaden en gebruiken:
+*(klik met de rechtermuisknop op de afbeeldingen en selecteer "Afbeelding opslaan als...")*
+
+[IMAGES] -->
+
+## Aanvullende informatie en argumenten
+
+### Mythen doorprikken
+
+Toen in mei 2022 het wetsontwerp over chatcontrole voor het eerst werd gepresenteerd, [prees de Europese Commissie het controversiële plan aan met verschillende argumenten](https://ec.europa.eu/commission/presscorner/detail/en/IP_22_2976). In wat volgt worden verschillende foutieve beweringen in onderuit gehaald en wordt correcte informatie gegeven.
+
+#### ❌ Mythe #1: “Tegenwoordig worden er massaal foto's en video's van seksueel misbruik van kinderen verspreid op internet. In 2021 werden 29 miljoen gevallen gemeld aan het Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen in de Verenigde Staten.”
+
+✅ *Hoe het werkelijk zit:*
+
+Het is misleidend om uitsluitend te spreken van afbeeldingen van seksueel misbruik van kinderen in het kader van chatcontrole. Zeker, materiaal over seksuele uitbuiting van kinderen is vaak beeldmateriaal van seksueel geweld tegen minderjarigen. Maar een [internationale werkgroep van kinderbeschermingsinstellingen](https://www.ohchr.org/sites/default/files/TerminologyGuidelines_en.pdf) wijst erop dat onder crimineel materiaal ook opnames vallen van minderjarigen waarbij geen geweld wordt gebruikt of geen andere persoon betrokken is. Ook worden opnames gemaakt in alledaagse situaties genoemd, zoals een familiefoto van een kind in bikini of naakt in de laarzen van diens ouder. Ook opnames gemaakt of gedeeld zonder medeweten van de minderjarige vallen hieronder. Strafbaar kindermisbruikmateriaal omvat ook strips, tekeningen, manga/anime en door de computer gegenereerde afbeeldingen van fictieve minderjarigen. Onder criminele afbeeldingen vallen ten slotte ook zelfgemaakte seksuele opnames van minderjarigen, bijvoorbeeld om door te sturen naar partners van dezelfde leeftijd (“seksten”). De studie stelt daarom de term “afbeeldingen van seksuele uitbuiting” van minderjarigen voor als een juiste omschrijving. In dit kader zijn opnames van kinderen (tot 14 jaar) en jongeren (tot 18 jaar) even strafbaar.
+
+#### ❌ Mythe #2: "Alleen al in 2021 werden wereldwijd 85 miljoen afbeeldingen en video's van seksueel misbruik van kinderen gemeld."
+
+✅ *Hoe het werkelijk zit:*
+
+Er circuleren veel misleidende beweringen over hoe de omvang van seksueel uitbuitende afbeeldingen van minderjarigen kan worden gekwantificeerd. Het cijfer dat de Europese Commissie gebruikt om haar plannen te verdedigen, is afkomstig van de niet-gouvernementele organisatie Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen in de Verenigde Staten en bevat dubbelen, omdat kindermisbruikmateriaal meerdere keren wordt gedeeld en vaak niet wordt verwijderd. Exclusief dubbelen blijven er van de 85 miljoen gerapporteerde gevallen 22 miljoen unieke opnames over.
+
+75 procent van alle meldingen die in 2021 bij het Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen binnenkwamen kwam van Meta (Facebook, Instagram, Whatsapp). De eigen interne analyse van Facebook zegt dat “meer dan 90 procent van [kindermisbruikmateriaal op Facebook in 2020] identiek was aan, of visueel vergelijkbaar was met, eerder gerapporteerde inhoud. En kopieën van slechts zes video's waren verantwoordelijk voor meer dan de helft van het materiaal waarin kinderen werden uitgebuit." De veel geciteerde cijfers van het Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen beschrijven dus niet echt de omvang van online opnames van seksueel geweld tegen kinderen. Ze beschrijven eerder hoe vaak Facebook kopieën ontdekt van beeldmateriaal waarvan het al op de hoogte is. Ook dat is relevant.
+
+Niet alle unieke opnames die aan het Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen zijn gemeld, tonen geweld tegen kinderen. De 85 miljoen afbeeldingen die werden gerapporteerd door het Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen bevatten bijvoorbeeld ook gevallen van seksten met instemming. Het aantal afbeeldingen van misbruik dat in 2021 aan het Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen werd gemeld, bedroeg 1,4 miljoen.
+
+[7% van de wereldwijde rapporten over verdachte activiteit van het Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen gaat naar de Europese Unie.](https://www.missingkids.org/blog/2020/we-are-in-danger-of-losing-the-global-battle-for-child-safety)
+
+Bovendien blijven zelfs op Facebook, waar chatcontrole al lang vrijwillig wordt gebruikt, de cijfers voor de verspreiding van misbruikmateriaal stijgen. Chatcontrole is dus geen oplossing. ([Bron](https://netzpolitik.org/2022/ncmec-figures-explained-how-the-spectre-of-millionfold-abuse-haunts-european-policy-makers/))
+
+#### ❌ Mythe #3: "64% meer meldingen van bevestigd seksueel misbruik van kinderen in 2021 in vergelijking met het voorgaande jaar."
+
+✅ *Hoe het werkelijk zit:*
+
+Dat de vrijwillige chatcontrole-algoritmen van grote dienstenaanbieders in de Verenigde Staten meer kindermisbruikmateriaal hebben gerapporteerd, geeft niet aan hoe de hoeveelheid kindermisbruikmateriaal in het algemeen zich heeft ontwikkeld. De configuratie van de algoritmen zelf heeft een grote impact op het aantal rapporten over verdachte activiteit. Bovendien laat de toename zien dat de oplage van kindermisbruikmateriaal niet te sturen is door middel van chatcontrole.
+
+#### ❌ Mythe #4: "Europa is wereldwijd het middelpunt voor het meeste kindermisbruikmateriaal."
+
+✅ *Hoe het werkelijk zit:*
+
+[7% van de wereldwijde rapporten over verdachte activiteit van het Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen gaat naar de Europese Unie.](https://www.missingkids.org/blog/2020/we-are-in-danger-of-losing-the-global-battle-for-child-safety) Overigens melden Europese wetshandhavingsinstanties zoals Europol en de nationale politie misbruikmateriaal bewust niet  bij opslagdiensten aan voor verwijdering, dus de hoeveelheid materiaal dat hier is opgeslagen kan op die manier niet afnemen.
+
+#### ❌ Mythe #5: “Een door Europol gesteund onderzoek op basis van een rapport van een online dienstverlener heeft geleid tot de redding van 146 kinderen wereldwijd, met meer dan 100 verdachten geïdentificeerd in de EU.”
+
+✅ *Hoe het werkelijk zit:*
+
+De betreffende melding werd gedaan door een aanbieder van wolkopslag, niet door een aanbieder van communicatiediensten. Om wolkopslag door te lichten, is het niet nodig om het afluisteren van ieders communicatie verplicht te stellen. Als je de daders van online misdaden met betrekking tot kindermisbruikmateriaal wilt pakken, moet je gebruik maken van zogenaamde honingpotten en andere methodes waarbij het niet nodig is om de communicatie van de hele bevolking in de gaten te houden.
+
+#### ❌ Mythe #6: “Bestaande middelen om relevant materiaal op te sporen zijn niet meer beschikbaar als de huidige tijdelijke oplossing afloopt.”
+
+✅ *Hoe het werkelijk zit:*
+
+Aanbieders van beheerdiensten (bestandbeheerders, beheerders van wolkopslag) en aanbieders van sociale media mogen blijven scannen nadat de ePrivacy-vrijstelling is verlopen. Voor aanbieders van communicatiediensten zou de vrijstellingsregeling voor het vrijwillig scannen van gesprekken kunnen worden uitgebreid zonder dat alle aanbieders verplicht moeten scannen.
+
+#### ❌ Mythe #7: Misleidende metaforen: 
+  - **Chatcontrole is “als een spamfilter”.**
+  - **Chatcontrole is “als een magneet die zoekt naar een speld in een hooiberg: de magneet ziet het hooi niet”.**
+  - **Chatcontrole is “als een politiehond die brieven besnuffelt: die heeft geen idee wat erin zit”.** 
+  - **De inhoud van je communicatie wordt door niemand gezien als er geen treffer is.** 
+  - **“Er vindt al opsporing plaats voor cyberveiligheidsdoeleinden, zoals het detecteren van links in WhatsApp” of spamfilters.**
+
+✅ *Hoe het werkelijk zit:*
+
+Malware- en spamfilters maken de inhoud van privécommunicatie niet bekend aan derden en leiden er niet toe dat onschuldige mensen worden gebrandmerkt. Ze leiden niet tot het verwijderen of langdurig blokkeren van profielen in sociale media of op online diensten.
+
+#### ❌ Mythe #8: “Wat de opsporing van nieuw misbruikmateriaal op het net betreft, is het aantal treffers ruim 90%. … Sommige bestaande technologieën voor het detecteren van kinderlokkerij (zoals die van Microsoft) hebben een 'nauwkeurigheidspercentage' van 88%, vóór menselijke beoordeling."
+
+✅ *Hoe het werkelijk zit:*
+
+Met een onbeheersbaar aantal berichten resulteert zelfs een klein foutenpercentage in ontelbare fout-positieven die het aantal correcte berichten ver kunnen overtreffen. Zelfs met een succespercentage van 99% zou dit betekenen dat van de 100 miljard berichten die dagelijks alleen al via Whatsapp worden verzonden, 1 miljard (dus  1,000,000,000) fout-positieve meldingen moeten worden geverifieerd. En dat is elke dag en alleen nog maar op één platform. De "menselijke beoordelingslast" voor de rechtshandhaving zou enorm zijn, terwijl de achterstand en de overbelasting van middelen hen al tegenwerkt.
+
+Daarbij legde een [vrijheid van informatie-verzoek van voormalig Europarlementariër Felix Reda](https://www.asktheeu.org/en/request/technologies_for_the_detection_o#incoming-39916) het feit bloot dat deze beweringen over de nauwkeurigheid van automatische scans afkomstig zijn van de industrie---van degenen die een gevestigd belang hebben bij deze beweringen, omdat ze opsporingstechnologieën willen verkopen (bedrijven als Thorn en Microsoft). Deze bedrijven weigeren hun technologie aan onafhankelijke testen te onderwerpen. We moeten hun beweringen daarom ook niet zomaar slikken.
+
+[De EU-evaluatie van instrumenten voor het opsporen van kindermisbruik is uitsluitend gebaseerd op beweringen van de industrie die ze klakkeloos hebben overgenomen.](https://www.euractiv.com/section/digital/news/eu-assessment-of-child-abuse-detection-tools-based-on-industry-data/)
+
+### Massasurveillance is de verkeerde aanpak om kindermisbruikmateriaal en seksuele uitbuiting te bestrijden
+
+- **Het scannen van privéberichten en chats legt de verspreiding van kindermisbruikmateriaal niet stil.** Facebook oefent bijvoorbeeld al jaren chatcontrole uit en het aantal geautomatiseerde rapporten neemt elk jaar toe, meest recentelijk tot 22 miljoen in 2021.
+- **Verplichte chatcontrole zal de daders** die kindermisbruikmateriaal opnemen en delen **niet opsporen**. Misbruikers delen hun materiaal niet via commerciële email-, berichten- of chatdiensten, maar organiseren zichzelf via zelfbeheerde geheime forums zonder controle-algoritmen. Misbruikers uploaden meestal ook afbeeldingen en video's als gecodeerde archieven en delen alleen de links en wachtwoorden. Algoritmen voor chatcontrole herkennen geen versleutelde archieven of links.
+- **De juiste benadering zou zijn om opgeslagen kindermisbruikmateriaal te verwijderen daar waar het online wordt beheerd.** [Europol rapporteert echter geen](https://ipexl.europarl.europa.eu/IPEXL-WEB/download/file/082d2908811d46d301814771a13101cb) bekend kindermisbruikmateriaal aan de beheerders.
+- **Chatcontrole schaadt de vervolging van kindermisbruik** door onderzoekers te overspoelen met miljoenen geautomatiseerde rapporten, waarvan de meeste strafrechtelijk niet eens relevant zijn.
+
+### Controle van berichten en chats schaadt iedereen
+
+- **Alle burgers worden zonder reden verdacht van het plegen van een misdrijf.** Tekst- en fotofilters scannen alle berichten, zonder uitzondering. **Er is geen rechter nodig om tot dergelijke surveillance te bevelen---in tegenstelling tot in de analoge wereld, waar de privacy van correspondentie en de vertrouwelijkheid van schriftelijke communicatie gegarandeerd is.** Volgens een arrest van het Europese Hof van Justitie is de permanente en algemene automatische analyse van privécommunicatie in strijd met fundamentele rechten (zaak C-511/18, paragraaf 192). Niettemin wil de EU nu dergelijke wetgeving aannemen. Het kan jaren duren voordat een rechter dit nietig verklaart. Daarom moeten we voorkomen dat de wetgeving überhaupt wordt aangenomen.
+- **De vertrouwelijkheid van persoonlijke elektronische correspondentie wordt opgeofferd.** Gebruikers van berichten-, chat- en emaildiensten lopen het risico dat hun privéberichten door anderen worden gelezen en geanalyseerd. Gevoelige foto's en tekst kunnen wereldwijd worden doorgestuurd naar onbekende entiteiten en in verkeerde handen vallen. Medewerkers van de Nationale Veiligheidsdienst in de Verenigde Staten hebben naar verluidt in het verleden [naaktfoto's van burgers verspreid](https://www.nytimes.com/2014/07/21/us/politics/edward-snowden-at-nsa-sexually-explicit-photos-often-shared.html?_r=0). Er is gemeld dat [een Google-ontwikkelaar minderjarigen stalkt](https://gawker.com/5637234/gcreep-google-engineer-stalked-teens-spied-on-chats).
+- **Willekeurige berichten- en chatcontrole beschuldigen elke dag ten onrechte honderden gebruikers.** Volgens de Zwitserse federale politie is [80% van de door machines gerapporteerde inhoud](https://www.republik.ch/2022/12/08/die-dunklen-schatten-der-chatkontrolle) niet illegaal. Het gaat bijvoorbeeld om onschuldige vakantiefoto's waarop naakt spelende kinderen op een strand te zien zijn. Ook in Ierland bleek het slechts bij [20%  van de rapporten](https://www.iccl.ie/news/an-garda-siochana-unlawfully-retains-files-on-innocent-people-who-it-has-already-cleared-of-producing-or-sharing-of-child-sex-abuse-material/) die in 2020 vanuit het Nationaal Centrum voor Vermiste en Uitgebuitte Kinderen werden ontvangen daadwerkelijk om kindermisbruikmateriaal te gaan.
+- **Veilig versleutelde communicatie loopt gevaar.** Tot nu toe konden versleutelde berichten niet worden doorzocht door de algoritmen. Om dat  te veranderen, zouden achterdeurtjes moeten worden ingebouwd in berichtensoftware. Zodra dat gebeurt, kan iedereen die over de benodigde technische middelen beschikt, misbruik maken van dit beveiligingslek---denk aan buitenlandse inlichtingendiensten en criminelen. Privécommunicatie, bedrijfsgeheimen en gevoelige overheidsinformatie zouden worden onthuld. Veilige versleuteling is nodig om minderheden, LHBTQI+-mensen, democratie-activisten, journalisten, en dergelijke te beschermen.
+- **Het strafrecht wordt geprivatiseerd.** In de toekomst zouden de algoritmen van bedrijven zoals Facebook, Google en Microsoft bepalen welke gebruiker verdacht is en welke niet. De voorgestelde wetgeving bevat geen transparantievereisten voor de gebruikte algoritmen. In de rechtsstaat behoort de opsporing van strafbare feiten in handen te zijn van onafhankelijke rechters en van ambtenaren die onder gerechtelijk toezicht te vallen.
+- **Willekeurige berichten- en chatcontrole schept een precedent en opent de sluizen voor meer opdringerige technologieën en wetgeving.** Het inzetten van technologie voor het automatisch toezicht houden op alle online communicatie is gevaarlijk. Het kan in de toekomst heel gemakkelijk voor andere doeleinden worden gebruikt, bijvoorbeeld door te scannen op schendingen van het auteursrecht, drugsmisbruik, of 'schadelijke inhoud'. In autoritaire staten is dergelijke technologie nuttig om tegenstanders van de regering en democratie-activisten te identificeren en te arresteren. Als de technologie eenmaal volledig is ingezet, is er geen weg meer terug.
+
+### Berichten- en chatcontrole schaadt kinderen en slachtoffers van misbruik
+
+Voorstanders beweren dat het willekeurig scannen van berichten en chats de vervolging van kindermisbruik zou vergemakkelijken. Dit argument is echter controversieel, ook onder slachtoffers van kindermisbruik. Berichten- en chatcontrole kan slachtoffers en potentiële slachtoffers van seksuele uitbuiting schade toebrengen, om de volgende redenen:
+
+1. **Veilige ruimtes worden kapotgemaakt.** Slachtoffers van seksueel geweld hebben vooral behoefte aan de mogelijkheid om veilig en vertrouwelijk te communiceren om advies en ondersteuning te zoeken. Bijvoorbeeld om veilig onderling gedachten uit te wisselen, of te spreken met hun therapeuten of advocaten. De introductie van continu alles scannen neemt hen deze veilige ruimtes af. Dit kan slachtoffers ontmoedigen om hulp en ondersteuning te zoeken.
+2. **Zelfgemaakte naaktfoto's van minderjarigen (seksten) komen in handen van bedrijfsmedewerkers** en politie terecht waar ze niet thuishoren en niet veilig zijn.
+3. **Minderjarigen worden gecriminaliseerd.** Vooral jongeren delen vaak intieme opnames met elkaar (seksten). Als er berichten- en chatcontrole is, kunnen hun foto's en video's in de handen van rechercheurs terechtkomen. Duitse misdaadstatistieken tonen aan dat [bijna 40% van alle onderzoeken naar kindermisbruikmateriaal gericht zijn op minderjarigen](https://www.polizei-beratung.de/startseite-und-aktionen/aktuelles/detailansicht/polizeiliche-kriminalstatistik-2021/).
+4. **Willekeurige berichten- en chatcontrole stop de verspreiding van illegaal materiaal niet, maar maakt het juist moeilijker om seksuele uitbuiting van kinderen te vervolgen.** Het moedigt overtreders aan om ondergronds te gaan en privé versleutelde servers te gebruiken die onmogelijk te detecteren en te onderscheppen zijn. Zelfs op open kanalen damt willekeurige bericht- en chatcontrole de hoeveelheid materiaal die wordt verspreid niet in, zoals blijkt uit het voortdurend stijgende aantal automatische meldingen.
+
+## Alternatieven
+
+### Versterk de capaciteit van de rechtshandhaving
+
+Momenteel is de capaciteit van de rechtshandhaving zo ontoereikend dat het vaak maanden en jaren duurt om aanwijzingen op te volgen en verzamelde gegevens te analyseren. Bekend materiaal wordt vaak niet geanalyseerd of verwijderd. Degenen achter het misbruik delen hun materiaal niet via Facebook of vergelijkbare kanalen, maar op het duistere internet. Om daders en producenten op te sporen moet er undercover politiewerk plaatsvinden in plaats van schaarse capaciteit te verspillen aan het controleren van vaak irrelevante machinemeldingen. Het is ook essentieel om de verantwoordelijke onderzoekseenheden te versterken wat betreft personeel en financiële middelen, om grondige en duurzame onderzoeken op lange termijn te waarborgen. Er moeten betrouwbare normen en richtlijnen voor de politiebehandeling van onderzoeken naar seksueel misbruik worden ontwikkeld en nageleefd.
+
+### Pak symptomen aan, maar vooral ook de oorzaak
+
+In plaats van ineffectieve technische pogingen om de verspreiding van misbruikmateriaal tegen te gaan, moeten alle inspanningen in de eerste plaats gericht zijn op het voorkomen van dergelijke opnames. Preventieplannen en trainingen spelen een sleutelrol, omdat de overgrote meerderheid van de gevallen van misbruik zelfs nooit bekend wordt. Slachtofferhulporganisaties hebben vaak te kampen met instabiele financiering.
+
+### Maak hulp voor (potentiële) slachtoffers snel en eenvoudig beschikbaar
+
+1. **Verplichte meldingsmechanismen bij online diensten:** Om preventie van online misbruik en met name kinderlokkerij effectiever te maken, zouden online diensten verplicht moeten worden om meldingsfuncties prominent op hun platformen te plaatsen. Als de dienst is gericht op, of wordt gebruikt door, jongeren of kinderen, zouden aanbieders ook moeten worden verplicht hen te informeren over de risico's van online kinderlokkerij.
+2. **Hulplijnen en adviescentra:** Veel nationale hulplijnen die gevallen van gemeld misbruik behandelen, kampen met financiële problemen. Het is van essentieel belang dat er voldoende capaciteit is om de gemelde gevallen op te volgen.
+
+### Verbeter mediawijsheid
+
+Het aanleren van digitale geletterdheid op jonge leeftijd is een essentieel onderdeel van het beschermen van kinderen en jongeren online. De kinderen moeten zelf de kennis en het gereedschap hebben om veilig op het internet te surfen. Ze moeten erop worden gewezen dat er ook online gevaren op de loer liggen en patronen van kinderlokkerij leren herkennen en in twijfel trekken. Dit kan bijvoorbeeld worden bereikt door gerichte programma's in scholen en opleidingscentra, waarin getraind personeel kennis overdraagt en discussies leidt. Kinderen moeten leren zich uit te spreken, te reageren en misbruik te melden, zelfs als het misbruik binnen hun vertrouwenssfeer komt (dat wil zeggen door mensen die dicht bij hen staan of andere mensen die ze kennen en vertrouwen), wat vaak het geval is. Ze moeten ook toegang hebben tot veilige, toegankelijke en voor hun leeftijd geschikte kanalen om misbruik zonder schroom te kunnen melden.
+
+## Documentenpoel
+
+- [Europees Parlement wetgevingswaarnemingspost](https://oeil.secure.europarl.europa.eu/oeil/popups/ficheprocedure.do?lang=en&reference=2022/0155(OLP)) (voortdurend bijgewerkte stand van zaken) 🇬🇧
+
+### Europees Parlement
+- [Ontwerpverslag van de rapporteur](https://www.europarl.europa.eu/doceo/document/LIBE-PR-746811_EN.html) (25 april 2023) 🇳🇱
+- [Aanvullende effectbeoordeling](https://www.europarl.europa.eu/RegData/etudes/STUD/2023/740248/EPRS_STU(2023)740248_EN.pdf) (april 2023) [PDF] 🇬🇧
+- [Presentatie van bevindingen](https://www.patrick-breyer.de/wp-content/uploads/2023/01/Presentation-of-Findings_LIBE-Shadows-Meeting-25-01-2021_rev.pdf): Gerichte vervangende effectbeoordeling van het voorstel van de Commissie (25 januari 2023) [PDF] 🇬🇧
+
+### Raad van de Europese Unie (Raad)
+
+- [Raadsdocumenten](https://www.consilium.europa.eu/en/documents-publications/public-register/public-register-search/results/?WordsInSubject=&WordsInText=%22child+sexual+abuse%22&DocumentNumber=&InterinstitutionalFiles=&DocumentDateFrom=&DocumentDateTo=&MeetingDateFrom=&MeetingDateTo=&DocumentLanguage=EN&OrderBy=DOCUMENT_DATE+DESC&ctl00%24ctl00%24cpMain%24cpMain%24btnSubmit=) (voortdurend bijgewerkt) 🇪🇺
+- [Openbare zitting](https://video.consilium.europa.eu/event/en/26852) van de Raad Justitie en Binnenlandse Zaken met verklaringen van het Zweedse voorzitterschap en commissaris Ylva Johansson (08 juni 2023) [video] 🇪🇺
+- [Gemeenschappelijk standpunt](https://www.patrick-breyer.de/wp-content/uploads/2023/05/2023-03-03-conseil-csam-declaration-LMG-10MS-Belgium-Bulgaria-Cyprus-Hungary-Ireland-Italy-Latvia-Lithuania-Romania-and-Spain.pdf) van de gelijkgestemde groep (LMG) van lidstaten (27 april 2023) [PDF] 🇬🇧
+- [Advies Juridische Dienst van de Raad](https://www.patrick-breyer.de/wp-content/uploads/2023/05/st08787.en23-leak.pdf) (26 april 2023) [PDF] 🇬🇧
+- [Standpunten van de lidstaten over versleuteling](https://www.patrick-breyer.de/wp-content/uploads/2023/05/law-enforcement-working-party-document-encryption.pdf) (12 april 2023) [PDF] 🇬🇧
+- [Standpunten van de lidstaten over Artikelen 12-15](https://www.patrick-breyer.de/wp-content/uploads/2023/05/2023-04-12-MS-comments-on-CSAM-encryption.pdf) (12 april 2023) [PDF] 🇬🇧
+
+### Europese Commissie
+
+- [Niet-paper](https://cdn.netzpolitik.org/wp-upload/2023/06/2023-05-17_COM_CSAR_response-on-legal-assessments.pdf) Opmerkingen van de diensten van de Commissie over enkele elementen van het ontwerp van de Opzet Definitieve Aanvullende Effectbeoordeling (17 mei 2023) [PDF] 🇬🇧
+- [Aanwijzing](https://www.politico.eu/wp-content/uploads/2022/10/27/Briefing-for-a-meeting-between-Yva-Johansson-and-Charlotte-Caubel-27-SEPT-2022-1-Redacted.pdf) voor commissaris Ylva Johansson voor een ontmoeting met een Franse minister (27 september 2022) [PDF] 🇬🇧
+- [Openbare raadplegingen door de Commissie](https://ec.europa.eu/info/law/better-regulation/have-your-say/initiatives/12726-Strijd-tegen-seksueel-misbruik-van-kinderen-opsporing-verwijdering-en-melding-van-illegale-online-inhoud_nl) (afgesloten op 12 september 2022) 🇳🇱
+- [Analyse van reacties op de openbare raadplegingen door de Commissie](https://maxim.tips/against-chatcontrol/) (19 september 2022) 🇬🇧
+- [Niet-paper](https://www.statewatch.org/media/3900/eu-com-csam-regulation-proportionality-note-9512-23.pdf) Evenwicht tussen kinderrechten en gebruikersrechten (16 mei 2022) [PDF] 🇬🇧
+- [Ontwerpverordening verplichte chatcontrole](https://eur-lex.europa.eu/legal-content/NL/TXT/?uri=COM%3A2022%3A209%3AFIN) 🇳🇱 
+- [Effectbeoordeling van de ontwerpverordening verplichte chatcontrole](https://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=SWD:2022:0209:FIN:EN:PDF) (11 mei 2022) [PDF] 🇬🇧
+- [Tweede opinie van de Raad voor regelgevingstoetsing](https://www.patrick-breyer.de/wp-content/uploads/2022/11/220128_Opinion-II-HOME-Child-Sexual-Abuse-annotated-fin.pdf) (28 maart 2022) [PDF] 🇬🇧
+- [Opinie van de Raad voor regelgevingstoetsing](https://edri.org/wp-content/uploads/2022/03/2022-03-21-csam-avis-rsb-15-fevrier.pdf) (15 februari 2022) [PDF] 🇬🇧
+- [Kwaliteitschecklist voor de Raad voor regelgevingstoetsing](https://www.patrick-breyer.de/wp-content/uploads/2022/11/210611_Opinion-I-HOME-responses-annotated-fin.pdf) (6 november 2021) [PDF] 🇬🇧
+
+### Verklaringen en beoordelingen
+
+- [Samenvatting van de verklaring van de kinderbeschermingsvereniging](https://www.patrick-breyer.de/en/statement-by-the-child-protection-association-der-kinderschutzbund-bundesverband-e-v-on-the-public-hearing-of-the-digital-affairs-committee-on-chat-control/) (Der Kinderschutzbund Bundesverband e.V.) over de openbare hoorzitting van de commissie Digitale Zaken over 'chatcontrole' (1 maart 2023) 🇬🇧
+- [Samenvatting van de verklaring van de federale commissaris voor gegevensbescherming en vrijheid van informatie](https://www.patrick-breyer.de/en/summary-of-statement-by-the-federal-commissioner-for-data-protection-and-freedom-of-information-on-the-public-hearing-of-the-committee-on-digital-affairs-of-the-german-bundestagon-the-topic-of/) over de openbare hoorzitting van de commissie voor digitale zaken van de Duitse Bondsdag over het onderwerp 'chatcontrole' (1 maart 2023) 🇬🇧
+- [Samenvatting van de verklaring het kantoor van het Openbaar Ministerie, Centraal en Contactpunt Cybermisdaad](https://www.patrick-breyer.de/en/summary-of-statement-public-prosecutors-office-central-and-contact-point-cybercrime-zac-on-the-public-hearing-of-the-digital-affairs-committee-of-the-german-bundestag-on-chat-control/) (ZAC) over de openbare hoorzitting van de commissie Digitale Zaken van de Duitse Bondsdag over 'chatcontrole' (1 maart 2023) 🇬🇧
+- [Europese Parlementaire Onderzoeksdienstrapport](https://www.europarl.europa.eu/RegData/etudes/BRIE/2022/738224/EPRS_BRI(2022)738224_EN.pdf) (december 2022) [PDF] 🇬🇧
+- [Juridisch advies van de Onderzoeksdienst van de Duitse Bondsdag](https://www.patrick-breyer.de/wp-content/uploads/2022/10/221007-WD-10-026-22-Bewertende-Analyse-zur-Chatkontrolle_EN-1.pdf) (7 oktober 2022) [PDF] 🇬🇧
+- [Advies van het Europees Economisch en Sociaal Comité](https://eur-lex.europa.eu/legal-content/NL/TXT/?uri=PI_EESC%3AEESC-2022-02804-AS) (13 september 2022) 🇳🇱
+- [Gezamenlijk advies van het Europees Comité voor gegevensbescherming en de Europese Toezichthouder voor gegevensbescherming 4/2022](https://edps.europa.eu/system/files/2022-07/22-07-28_edpb-edps-joint-opinion-csam_en.pdf) (28 juli 2022) [PDF] 🇬🇧
+
+### Vrijwillige chatcontrole
+
+- [Rapport over vrijwillige chatcontrole door Meta](https://transparency.fb.com/sr/eu-csam-derogation-report-2022/) (2022) [PDF] 🇬🇧
+- [Rapport over vrijwillige chatcontrole door Twitter](https://blog.twitter.com/en_us/topics/company/2022/twitter-s-eu-submission-for-2021-1232) (2022) 🇬🇧
+- [Rapport over vrijwillige chatcontrole door Google](https://storage.googleapis.com/transparencyreport/report-downloads/pdf-report-23_2021-8-2_2021-12-31_en_v1.pdf) (2021) [PDF] 🇬🇧
+- [Uitgelekte opinie van de Commissie doet alarmbellen rinkelen voor massale surveillance van privécommunicatie](https://edri.org/wp-content/uploads/2022/03/2022-03-21-csam-avis-rsb-15-fevrier.pdf) (23 maart 2022) [PDF] 🇬🇧
+- [Antwoord van de Commissie](https://www.patrick-breyer.de/wp-content/uploads/2022/03/20220309_COM_Answer_Global_Encryption_Day_Letter.pdf) op een [partijoverstijgende brief](https://www.patrick-breyer.de/en/world-encryption-day-lawmakers-warn-against-eu-attack-on-secure-encryption-and-confidential-digital-correspondence/) tegen verplichte chatcontrole (9 maart 2022) 🇬🇧
+- [Regeling vrijwillige chatcontrole](https://eur-lex.europa.eu/legal-content/NL/TXT/?uri=CELEX%3A32021R1232) 🇳🇱
+- [Juridisch advies van de Onderzoeksdienst van de Duitse Bondsdag](https://www.patrick-breyer.de/wp-content/uploads/2022/10/German_Bundestag_Legal_Assessment_final.pdf) (4 augustus 2021) [PDF] 🇬🇧
+- [Antwoorden van Europol op statistieken over de vervolging van online materiaal met seksueel misbruik van kinderen](https://www.patrick-breyer.de/wp-content/uploads/2021/06/2021-02-23-MEP-Breyer_CSEM-reports_EUROPOL_reply.pdf) (28 april 2021) [PDF] 🇬🇧
+- [Juridisch advies over de compatibiliteit van chatcontrole met de jurisprudentie van het Europese Hof van Justitie](https://www.patrick-breyer.de/wp-content/uploads/2021/03/Legal-Opinion-Screening-for-child-pornography-2021-03-04.pdf) (maart 2021) [PDF] 🇬🇧
+- [Effectbeoordeling door de Onderzoeksdienst van het Europees Parlement](https://www.europarl.europa.eu/RegData/etudes/STUD/2021/662598/EPRS_STU(2021)662598_EN.pdf) (5 februari 2021) [PDF] 🇬🇧
+- [Antwoorden van de Commissie](https://www.euractiv.com/wp-content/uploads/sites/2/2021/01/20201027_ePrivacy-derogation_follow-up-questions-COM_0611-clean.pdf) op vragen van de parlementsleden (27 oktober 2020) [PDF] 🇬🇧
+- [Antwoorden van de Commissie](https://www.euractiv.com/wp-content/uploads/sites/2/2021/01/EP-questions-9-October-final.pdf) op vragen van de parlementsleden (28 september 2020) [PDF] 🇬🇧
+- [Technische oplossingen om eind-tot-eind versleutelde communicatie door te lichten](https://www.patrick-breyer.de/wp-content/uploads/2023/02/SKM_C45820090717470-1.pdf) (september 2020) [PDF] 🇬🇧
+
+## Kritisch commentaar en verder lezen
+
+- **Bureau van de Hoge Commissaris voor de Mensenrechten: ["Rapport over het recht op privacy in het digitale tijdperk"](https://daccess-ods.un.org/access.nsf/Get?OpenAgent&DS=A/HRC/51/17&Lang=E)** (4 augustus 2022):
+    > “Overheden die encryptie proberen te beperken, hebben vaak niet aangetoond dat de beperkingen die ze zouden opleggen noodzakelijk zijn om een bepaald legitiem belang te dienen, gezien de beschikbaarheid van verschillende andere instrumenten en benaderingen die de informatie verschaffen die nodig is voor specifieke wetshandhaving of andere legitieme doeleinden. Dergelijke alternatieve maatregelen omvatten verbeterde traditionele politiezorg met betere middelen, clandestiene operaties, metadata-analyse en versterkte internationale politiesamenwerking.”
+
+- **VN-Comité voor de Rechten van het Kind, [Algemeen commentaar nr. 25](https://www.ohchr.org/en/documents/general-comments-and-recommendations/general-comment-no-25-2021-childrens-rights-relation)** (2021):
+    > "Elk digitaal toezicht op kinderen, samen met elke bijbehorende geautomatiseerde verwerking van persoonsgegevens, moet het recht van het kind op privacy respecteren en mag niet routinematig, willekeurig of zonder medeweten van het kind worden uitgevoerd..."
+- **Stichting Prostasia: [“Hoe de oorlog tegen kindermisbruikmateriaal verloren ging”](http://www.circleid.com/posts/20200819-how-the-war-against-child-abuse-material-was-lost/)** (19 augustus 2020)
+- **Europese Digitale Rechten (EDRi): [“Beschermt het surveilleren van kinderen hen echt? Onze zorgen over de tijdelijke kindermisbruikmateriaalverordening”](https://edri.org/our-work/is-surveilling-children-really-protecting-them-our-concerns-on-the-interim-csam-regulation/)** (24 september 2020)
+- **Maatschappelijke organisaties: ["Open brief: Visies van de maatschappelij op het verdedigen van privacy en het voorkomen van criminele handelingen"](https://edri.org/wp-content/uploads/2020/10/20201020-EDRi-Open-letter-CSAM-and-encryption-FINAL.pdf)** (27 oktober 2020)
+    > "we stellen voor dat de Commissie prioriteit geeft aan dit niet-technische werk, overtredende websites sneller verwijdert, boven scannen aan de cliëntzijde […]"
+
+- **Europese toezichthouder voor gegevensbescherming: [“Advies over het voorstel voor tijdelijke afwijkingen van Richtlijn 2002/58/EG ter bestrijding van online seksueel misbruik van kinderen”](https://edps.europa.eu/data-protection/our-work/publications/opinions/opinion-proposal-temporary-derogations-directive_en)** (10 november 2020)
+    > "Door het ontbreken van een effectbeoordeling bij het voorstel, moet de Commissie nog aantonen dat de maatregelen waarin het voorstel voorziet strikt noodzakelijk, doeltreffend en evenredig zijn om het beoogde doel te bereiken."
+
+- **Alexander Hanff** (slachtoffer van kindermisbruik en privacyprofessional): **[“Waarom ik geen voorstander ben van privacy-schendende maatregelen om kindermisbruik aan te pakken.”](https://www.linkedin.com/pulse/why-i-dont-support-privacy-invasive-measures-tackle-child-hanff)** (11 november 2020)
+    > “Als overlevende van misbruik vertrouw ik (en miljoenen andere overlevenden over de hele wereld) op vertrouwelijke communicatie zowel om steun te vinden als om de misdaden tegen ons te melden---om ons ons recht op privacy en vertrouwelijkheid te ontnemen is ons blootstellen aan nog meer schade en eerlijk gezegd hebben we wel genoeg geleden. […] het maakt niet uit welke stappen we nemen om misbruikers te vinden, het maakt niet uit hoeveel vrijheden of grondwettelijke rechten we vernietigen om aan die agenda te voldoen---het ZAL NIET voorkómen dat kinderen worden misbruikt, het zal het misbruik gewoon verder ondergronds duwen, het zal het steeds moeilijker maken om op te sporen, en zal er uiteindelijk toe leiden dat meer kinderen worden misbruikt.”
+
+- **[Iers slachtoffer van seksueel misbruik van kinderen](https://ec.europa.eu/info/law/better-regulation/have-your-say/initiatives/12726-Fighting-child-sexual-abuse-detection-removal-and-reporting-of-illegal-content-online/F3282960_en)** (5 juni 2022):
+    > "Het gebruik van de sluier van moraliteit en het mom van bescherming van de meest kwetsbaren en geliefden in onze samenlevingen om dit potentiële monster van een initiatief te introduceren, is verachtelijk."
+
+- **[Duits slachtoffer van seksueel misbruik van kinderen](https://ec.europa.eu/info/law/better-regulation/have-your-say/initiatives/12726-Bekampfung-des-sexuellen-Missbrauchs-von-Kindern-Erkennung-Entfernung-und-Meldung-illegaler-Online-Inhalte/F3264100_de)** (25 mei 2022):
+    > “Vooral als slachtoffer van seksueel misbruik vind ik het belangrijk dat er vertrouwd gecommuniceerd kan worden, bijvoorbeeld in zelfhulpgroepen en met therapeuten. Als versleuteling wordt ondermijnd, verzwakt dit ook de mogelijkheden voor slachtoffers van seksueel misbruik om hulp te zoeken.”
+
+- **[Frans slachtoffer van seksueel misbruik van kinderen](https://ec.europa.eu/info/law/better-regulation/have-your-say/initiatives/12726-Bekampfung-des-sexuellen-Missbrauchs-von-Kindern-Erkennung-Entfernung-und-Meldung-illegaler-Online-Inhalte/F3263149_de)** (23 mei 2022):
+    > “Ik ben zelf als kind slachtoffer geweest van seksueel geweld en ik ben ervan overtuigd dat onderwijs de enige manier is om vooruitgang te boeken op dit gebied. Algemeen surveilleren van communicatie zal kinderen niet helpen om te stoppen met lijden onder dit onaanvaardbare geweld.”
+
+- **AccessNow: ["De grondrechten vormen de kern van de nieuwe EU-regels voor online-inhoud"](https://www.euractiv.com/section/digital/opinion/the-fundamental-rights-concerns-at-the-heart-of-new-eu-online-content-rules/)** (19 november 2020)
+    > “In de praktijk betekent dit dat ze private bedrijven de leiding zouden geven over een zaak die de overheid zou moeten behandelen”
+
+- **Federale Orde van Advocaten (BRAK)** (in het Duits): **["Stellungnahme zur Übergangsverordnung gegen Kindesmissbrauch im Internet"](https://www.patrick-breyer.de/wp-content/uploads/2021/01/202011_Stellungnahme_BRAK_ePrivacy_Derogation.pdf)** (24 november 2020)
+    > „de beoordeling van feiten die verband houden met kindermishandeling behoort tot de verantwoordelijkheid van de advocatuur. De communicatie tussen advocaten en cliënten zal dan ook vaak relevante trefwoorden bevatten. […] Volgens de voorstellen van de Commissie moet worden gevreesd dat er in alle bovengenoemde constellaties regelmatig een schending van de vertrouwelijkheid zal plaatsvinden door het onvermijdelijke gebruik van relevante termen.”
+
+- **Alexander Hanff** (slachtoffer van kindermisbruik en privacy activist): **[“Het Europees Parlement staat op het punt een aanpassing goed te keuren die zal resulteren in de totale surveillance op meer dan 500 miljoen Europeanen”](https://www.linkedin.com/pulse/eu-parliament-pass-derogation-which-result-total-over-alexander-hanff/?published=t)** (4 december 2020)
+    > “Ik had geen vertrouwelijke communicatiemiddelen toen ik werd verkracht; al mijn communicatie werd gecontroleerd door mijn misbruikers---ik kon niets doen, er was geen vertrouwen. […] Ik kan het niet helpen dat ik me afvraag hoeveel anders mijn leven zou zijn geweest als ik toegang had gehad tot deze moderne technologieën. [De geplande stemming over de e-Privacy-aanpassing] zal misbruik ondergronds duwen, waardoor het veel moeilijker op te sporen zal zijn; het zal steungroepen ervan weerhouden om slachtoffers van misbruik te helpen---HET ZAL LEVENS VERNIETIGEN.”
+
+- **Duitse toezichthouder voor gegevensbescherming** (in het Duits): **["BfDI kritisiert versäumte Umsetzung von EU Richtlinie"](https://www.bfdi.bund.de/DE/Infothek/Pressemitteilungen/2020/30_Umsetzung-EU-Richtlinie.html)** (17 december 2020)
+    > “Een algemeen en niet-uitgelokt monitoren van digitale communicatiekanalen is niet proportioneel noch is het nodig om online kindermisbruik op te sporen. De strijd tegen seksueel geweld tegen kinderen moet worden aangepakt met gerichte en specifieke maatregelen. Het opsporingswerk is de taak van de rechtshandhavingsinstanties en mag niet worden uitbesteed aan particuliere aanbieders van berichtendiensten.”
+
+- **Europese Digitale Rechten (EDRi): [Afluisteren van privécommunicatie van kinderen: Vier verzamelingen van fundamentele rechtsproblemen voor kinderen (en alle anderen)](https://edri.org/our-work/children-private-communications-csam-fundamental-rights-issues/)** (10 februari 2021)
+    > “Net als bij andere soorten inhoudsscans (of het nu op platforms zoals YouTube is of in privécommunicatie), creëert het voortdurend scannen van alles van iedereen enorme risico's om te leiden tot massasurveillance door niet te voldoen aan de noodzaak- en evenredigheidstest. Bovendien creëert het een hellend vlak waar we beginnen met scannen op minder schadelijke gevallen (auteursrecht) en dan gaan we verder met moeilijkere kwesties (seksueel misbruik van kinderen, terrorisme) en voordat je beseft wat er is gebeurd, wordt alles scannen het nieuwe normaal.”
+
+- **Duitse orde van advocaten (DAV): ["Het willekeurig scannen van communicatie is onevenredig"](https://anwaltverein.de/de/newsroom/sn-25-21-anlassloses-inhalte-scannen-ist-unverh%C3%A4ltnism%C3%A4%C3%9Fig?file=files/anwaltverein.de/downloads/newsroom/stellungnahmen/2021/dav-position-paper-25-2021.pdf)** (9 maart 2021)
+    > “De Duitse orde van advocaten is uitdrukkelijk voorstander van het tegengaan van het voorbereiden en plegen van seksueel misbruik van kinderen en de verspreiding ervan via internet door middel van effectieve maatregelen op EU-niveau. De door de Commissie voorgestelde interimverordening zou echter flagrante onevenredige inbreuken op de grondrechten van gebruikers van op internet gebaseerde communicatiediensten mogelijk maken. Bovendien ontbreekt het de voorgestelde interimverordening aan voldoende procedurele waarborgen voor de betrokkenen. Daarom moet het wetsvoorstel in zijn geheel worden verworpen.”
+
+- **[Brief van de voorzitter van de Duitse orde van advocaten (DAV) en de voorzitter van de federale orde van advocaten (BRAK)](https://www.patrick-breyer.de/wp-content/uploads/2021/03/Praesidentenschreiben-BRAK-DAV_Trilog-Uebergangs-VO.pdf)** (in het Duits) (8 maart 2021)
+    > “Positieve treffers met daaropvolgende openbaarmaking aan overheids- en niet-overheidsinstanties zouden niet alleen worden gevreesd door beschuldigden, maar vooral door slachtoffers van seksueel misbruik van kinderen. In deze context is de absolute vertrouwelijkheid van juridische bijstand onontbeerlijk in het belang van de slachtoffers, vooral in deze zaken die vaak beladen zijn met schaamte. Met name in deze gevallen dient de cliënt de bevoegdheid te behouden om te bepalen welke inhoud van de opdracht aan wie openbaar mag worden gemaakt. Anders valt te vrezen dat slachtoffers van seksueel misbruik van kinderen geen juridisch advies zullen inwinnen.”
+
+- **[Strategische autonomie in gevaar: Europese technologiebedrijven waarschuwen voor verlaging van het niveau van gegevensbescherming in de EU](https://tutanota.com/blog/posts/european-autonomy-in-danger/)** (15 april 2021)
+    > “In het kader van het initiatief 'Bestrijding van seksueel misbruik van kinderen: detectie, verwijdering en melding van illegaal materiaal', is de Europese Unie van plan om de digitale privacy van correspondentie af te schaffen. Om illegale inhoud automatisch te detecteren, moeten alle privéchatberichten in de toekomst worden doorgelicht. Dit zou ook moeten gelden voor inhoud die tot nu toe is beveiligd met sterke eind-tot-eind versleuteling. Als dit initiatief wordt ingevoerd volgens het huidige plan, zou het onze Europese idealen en de onbetwistbare fundamenten van onze democratie, namelijk de vrijheid van meningsuiting en de bescherming van de persoonlijke levenssfeer, enorm schaden […]. Het initiatief zou ook de strategische autonomie van Europa en daarmee de in de EU gevestigde bedrijven ernstig schaden."
+
+- **Artikel in ["Welt.de: Misdaadscanners op elke slimme telefoon - EU plant grote surveillance-aanval"](https://www.welt.de/wirtschaft/webwelt/plus234828248/Netzueberwachung-EU-will-den-Kriminalscanner-auf-jedem-Smartphone.html)** (in het Duits) (4 november 2021)
+    > Deskundigen van politie en wetenschap zijn nogal kritisch over het plan van de EU: enerzijds vrezen ze veel foutieve meldingen door de scanners, anderzijds een alibifunctie van de wet. Daniel Kretzschmar, woordvoerder van de Federale Raad van de Vereniging van Duitse Rechercheurs, zegt dat de strijd tegen afbeeldingen van kindermisbruik "enorm belangrijk" is voor zijn vereniging. Toch is hij sceptisch: onverdachte personen kunnen gemakkelijk het middelpunt van onderzoeken worden. Tegelijkertijd, zegt hij, betekent het privatiseren van deze initiatiefonderzoeken “wetshandhaving afhankelijk maken van deze bedrijven, wat eigenlijk een staats- en soevereine taak is.“
+
+    > Thomas-Gabriel Rüdiger, hoofd van het Instituut voor Cybercriminologie aan de Brandenburgse politieuniversiteit is ook nogal kritisch over het EU-project. "Uiteindelijk zal het waarschijnlijk weer vooral minderjarigen raken", zegt hij tegen WELT. Rüdiger verwijst naar cijfers uit de misdaadstatistieken, volgens welke 43 procent van de geregistreerde misdrijven op het gebied van kindermisbruikmateriaal terug te voeren zou zijn op kinderen en adolescenten zelf. Dit is bijvoorbeeld het geval bij zogenaamde "seksten" en "schoolpleinpornografie", waarbij 13- en 14-jarigen elkaar onzedelijke foto's sturen.
+
+    > Echte daders, die je eigenlijk wilt pakken, worden waarschijnlijk liever niet gepakt. “Ze zijn zich bewust van wat ze hebben gedaan en gebruiken alternatieven. Vermoedelijk zullen USB-sticks en andere gegevensdragers dan weer steeds vaker worden gebruikt”, vervolgt Rüdiger.
+
+- **Europese Digitale Rechten (EDRi): [Chatcontrole: 10 principes om kinderen te verdedigen in het digitale tijdperk](https://edri.org/our-work/chat-control-10-principles-to-defend-children-in-the-digital-age/)** (9 februari 2022)
+    > “In overeenstemming met de EU-wetgeving inzake grondrechten moet het toezicht op of het onderscheppen van privécommunicatie of de metadata daarvan voor het opsporen, onderzoeken, of vervolgen van online kindermisbruikmateriaal beperkt blijven tot echte verdachten tegen wie een redelijke verdenking bestaat, naar behoren gerechtvaardigd en specifiek gerechtvaardigd zijn, en moet dit de nationale en EU-regels inzake politieoptreden, eerlijke rechtsgang, behoorlijk bestuur, non-discriminatie en waarborgen van de grondrechten naleven.”
+- **European Digital Rights (EDRi): [Gelekt advies van de Commissie doet alarmbellen rinkelen voor massale surveillance van privécommunicatie](https://edri.org/our-work/leaked-opinion-of-the-commission-sets-off-alarm-bells-for-mass-surveillance-of-private-communications/)** (23 maart 2022)
+    > In de aanloop naar het officiële voorstel later dit jaar dringen we er bij alle Europese commissarissen op aan hun verantwoordelijkheden voor de mensenrechten te onthouden en ervoor te zorgen dat een voorstel dat de kern van het recht op privacy van mensen, en de hoeksteen van de democratische samenleving, bedreigt, niet naar voren geschoven wordt.
+- **Raad van Europese Professionele Informatica Genootschappen (CEPIS): [Europa heeft recht op veilige communicatie en effectieve versleuteling](https://cepis.org/right-to-secure-communication/)** (maart 2022)
+    > “Volgens onze experts, academici en IT-deskundigen, hebben alle pogingen om chatcommunicatie te onderscheppen en uitgebreid te surveilleren via het scannen aan cliëntzijde een enorm negatieve impact op de IT-beveiliging van miljoenen Europese internetgebruikers en bedrijven. Daarom moeten een Europees recht op veilige communicatie en effectieve versleuteling voor iedereen de standaard worden.”

--- a/content/nl/docs/waarom-scannen-aan-clientzijde-de-eind-tot-eind-versleuteling-verbreekt.md
+++ b/content/nl/docs/waarom-scannen-aan-clientzijde-de-eind-tot-eind-versleuteling-verbreekt.md
@@ -1,6 +1,6 @@
 ---
 title: "Waarom scannen aan de cliëntzijde de eind-to-eind-versleuteling verbreekt"
-description: "Answers to frequently asked questions."
+description: "Bespreking van waarom het scannen aan cliëntzijde de eind-tot-eind-versleuteling van digitale communicatie verbreekt."
 lead: "Oorspronkelijke publicatie: <a href='https://www.eff.org/deeplinks/2019/11/why-adding-client-side-scanning-breaks-end-end-encryption'>Why Adding Client-Side Scanning Breaks End-To-End Encryption</a> <br> Auteur: Erica Portnoy<br> Publicatie: Electronic Frontier Foundation<br> 
 Datum: 1 november 2019<br> Hier de vertaling in het Nederlands."
 date: 2020-10-06T08:49:31+00:00


### PR DESCRIPTION
This change adds an NL translation of [Patrick Breyer's Chat Control 2.0 dossier](https://www.patrick-breyer.de/en/posts/chat-control/) to the website.