### PR TITLE
Add news section to frontpage

### DIFF
--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -18,3 +18,6 @@
 
 - id: more-info
   translation: "Meer informatie"
+
+- id: more-news
+  translation: "Meer nieuws"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,6 +11,22 @@
     </div>
   </div>
 </section>
+<section>
+  <h2 id="bekijk-het-zelf">Laatste nieuws</h2>
+  {{ range ( where .Site.RegularPages "Section" "nieuws" | first 3 ) }}
+  <div class="card">
+    <div class="card-body">
+      <h2 class="h3"><a class="stretched-link text-body" href="{{ .RelPermalink }}">{{ .Params.title }}</a></h2>
+      <p>{{ .Params.lead | safeHTML }}</p>
+      {{ partial "main/blog-meta.html" . -}}
+    </div>
+  </div>
+{{end}}
+</section>
+<div class="col-lg-9 col-xl-8 text-center">
+  <a class="btn btn-primary btn-lg px-4 mb-2" href="/nieuws" role="button">{{ i18n "more-news" }}</a>
+  <!-- <p class="meta">Open-source MIT Licensed. <a href="https://github.com/h-enk/doks">GitHub v{{ $data := getJSON "/package.json" }}{{ $data.version }}</a></p> -->
+</div>
 {{ end }}
 
 {{ define "phone" }}


### PR DESCRIPTION
This change adds a section with the 3 latest news items to the frontpage, plus a button to link to the news page.